### PR TITLE
Add pusher to requirements

### DIFF
--- a/GLbackend/requirements.txt
+++ b/GLbackend/requirements.txt
@@ -11,6 +11,7 @@ djangorestframework-simplejwt==5.3.0
 idna==3.6
 joblib==1.3.2
 numpy==1.26.2
+pusher==3.3.2
 Pillow==10.1.0
 PyJWT==2.8.0
 python-dotenv==1.0.0


### PR DESCRIPTION
Fixes #8 

Steps to verify:

1. Create a virtualenv
2. Run `pip install -r requirements.txt`
3. Run `python manage.py check`
4. Verify that the reported `ModuleNotFoundError: No module named 'pusher'` does not appear anymore